### PR TITLE
Towards standarizing projects StateMachine interfase 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.project
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,9 @@ repository = "https://github.com/klispap/generic-state-machine-rs"
 
 [dependencies]
 derivative = "2.2.0"
-anyhow = "1.0.13"
-tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
+thiserror = "1.0.26"
+anyhow = { version = "1.0.13", optional = true }
+tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true}
+
+[features]
+async = ["tokio", "anyhow"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+use std::fmt::Debug;
+use thiserror::Error;
+
+pub type Result<S> = std::result::Result<S, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("State Machine is not initialized")]
+    NoCurrentState,
+
+    #[error("Initial state can only be set once.")]
+    InitialStateDoubleSet,
+
+    #[error("Access mutex error: {0}")]
+    AccessMutex(String),
+
+    #[error("Current state does not have transition to the incoming event: {0}")]
+    EventNotMachingState(String),
+}
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(e: std::sync::PoisonError<T>) -> Self {
+        Error::AccessMutex(e.to_string())
+    }
+}
+
+impl<S: Debug, E: Debug> From<ContexError<S, E>> for Error {
+    fn from(e: ContexError<S, E>) -> Self {
+        Error::EventNotMachingState(e.to_string())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ContexError<S: Debug, E: Debug> {
+    #[error("State {0:?} does not have transsition for event {1:?}")]
+    EventNotMachingState(S, E),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!    where input E is the trigger event and the return value is the new state.
 //!  * Output generation is left to the user to allow the implementation to be as generic as possible.
 //!    You can print or call exernal functions to produce the desired output
-//!  
+//!
 //! ## Implement Moore state machine:
 //!  * Define transition functions that calculate the next state and use that to produce any outputs
 //!
@@ -33,6 +33,7 @@
 //! ```
 //!
 //! ```rust
+//! #[cfg(features = "async")]
 //! #[tokio::test]
 //! async fn state_machine_example() -> Result<()> {
 //!     let mut fsm = AsyncStateMachine::<bool, usize>::new(5);
@@ -104,15 +105,17 @@
 //!
 //! fsm.add_transition(2, 3, tf);
 //! fsm.add_transition(3, 1, tf);
-//! fsm.set_state(1);
+//! fsm.initial_state(1);
 //!
 //! println!("{:?}", fsm);
 //!
-//! assert_eq!(1, fsm.execute(1));
-//! assert_eq!(2, fsm.execute(2));
-//! assert_eq!(3, fsm.execute(3));
+//! assert_eq!(2, fsm.execute(2).unwrap());
+//! assert_eq!(3, fsm.execute(3).unwrap());
+//! assert_eq!(1, fsm.execute(1).unwrap());
 //!
 //! ```
+mod error;
 pub mod primitives;
+#[cfg(feature = "async")]
 pub mod state_machine;
 mod tests;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -62,7 +62,7 @@ where
 
     /// Get the current state
     pub async fn current_state(&self) -> S {
-        self.state_machine.lock().await.current_state()
+        self.state_machine.lock().await.current_state().unwrap()
     }
 
     /// Force the current state to the state provided. Used to set the initial state
@@ -108,6 +108,10 @@ async fn state_machine_task<S, E>(
             break;
         }
 
-        state_machine.lock().await.execute(next_event.unwrap());
+        state_machine
+            .lock()
+            .await
+            .execute(next_event.unwrap())
+            .unwrap();
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,17 +20,18 @@ mod primitive_tests {
     #[test]
     fn primitive_test_i32() {
         let mut fsm = StateMachine::<i32, i32>::new();
-        fsm.add_states(&mut vec![1, 2, 3])
+        fsm.add_states(&[1, 2, 3])
             .add_transition(1, 2, |_fsm, _event| 2)
             .add_transition(2, 3, tf)
             .add_transition(3, 1, tf)
-            .set_state(1);
+            .initial_state(1)
+            .unwrap();
 
-        println!("{:?}", fsm);
+        println!("fsm: {:?}", fsm);
 
-        assert_eq!(1, fsm.execute(1));
-        assert_eq!(2, fsm.execute(2));
-        assert_eq!(3, fsm.execute(3));
+        assert_eq!(2, fsm.execute(2).unwrap());
+        assert_eq!(3, fsm.execute(3).unwrap());
+        assert_eq!(1, fsm.execute(1).unwrap());
     }
 
     #[test]
@@ -48,7 +49,7 @@ mod primitive_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "async"))]
 mod state_machine_tests {
     use crate::state_machine::AsyncStateMachine;
 


### PR DESCRIPTION
1. Start of error handling added to primitives.rs
2. Default trait requirement removed from S at StateMachineTransitions
3. Test case corrected
4. add_states now accepts slice in order to be more generic
5. Crate is split to features. Async StaterMachine is compiled only on
   command
6. target folder is added to .gitignore file to avoid accidentally
   commit it.